### PR TITLE
Added the support of long long int (64 bit width) for integers 

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -115,7 +115,7 @@ comma                ([,])
 
 {integer}               {
   /*octal if first digit is 0, hexadecimal if first two characters are 0x or 0X, decimal otherwise*/
-  yylval.integer = strtol(yytext, NULL, 0);
+  yylval.integer = strtoll(yytext, NULL, 0);
   return CONST_INT;
 }
 


### PR DESCRIPTION
This PR fixes the error arising in hexadecimal computation which gives a 64 bit width over 32 bit width for input.The long long int strtoll() gives an edge over long int strtol() as it gives range of -2^63 to 2^63 – 1 over -2^31 to 2^31 – 1.
This resolves the error as it increases the range and gives the correct result with strtoll() function.