### PR TITLE
Added column number in error message for precise error detection

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -21,17 +21,17 @@
     yylloc.first_line = curr_line;
     yylloc.first_column = columnnumber;
     for(s = yytext; *s != '\0'; s++)
+    {
+      if(*s == '\n')
       {
-        if(*s == '\n')
-        {
-          curr_line += 1;
-          columnnumber = 0;
-        }
-        else
-        {
-          columnnumber += 1;
-        }
+        curr_line += 1;
+        columnnumber = 0;
       }
+      else
+      {
+        columnnumber += 1;
+      }
+    }
     yylloc.last_line = curr_line;
     yylloc.last_column = columnnumber - 1;
   }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -4,8 +4,8 @@
   #include "symbol_table.h"
 
   int linenumber = 1;
+  int columnnumber = 1;
   int curr_line = 1;
-  int curr_col  = 1;
   int assignment_flag = 0;
   int for_loop_flag = 0;
   int function_flag = 0;
@@ -15,27 +15,27 @@
   void yyerror(char* s);
   int yylex();
  
-static void updating_column()
-{
-  yylloc.first_line   = curr_line;
-  yylloc.first_column = curr_col;
+  static void updating_column()
+  {
+    yylloc.first_line = curr_line;
+    yylloc.first_column = columnnumber;
 
-    char * s;
-  for(s = yytext; *s != '\0'; s++)
-    {
-      if(*s == '\n')
+      char * s;
+    for(s = yytext; *s != '\0'; s++)
       {
-        curr_line++;
-        curr_col = 0;
+        if(*s == '\n')
+        {
+          curr_line ++;
+          columnnumber = 0;
+        }
+        else
+        {
+          columnnumber ++;
+        }
       }
-      else
-      {
-        curr_col++;
-      }
-    }
-  yylloc.last_line   = curr_line;
-  yylloc.last_column = curr_col-1;
-}
+    yylloc.last_line = curr_line;
+    yylloc.last_column = columnnumber-1;
+  }
 
 #define YY_USER_ACTION updating_column();
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -17,28 +17,25 @@
  
   static void updating_column()
   {
+    char* s;
     yylloc.first_line = curr_line;
     yylloc.first_column = columnnumber;
-
-      char * s;
     for(s = yytext; *s != '\0'; s++)
       {
         if(*s == '\n')
         {
-          curr_line ++;
+          curr_line += 1;
           columnnumber = 0;
         }
         else
         {
-          columnnumber ++;
+          columnnumber += 1;
         }
       }
     yylloc.last_line = curr_line;
-    yylloc.last_column = columnnumber-1;
+    yylloc.last_column = columnnumber - 1;
   }
-
-#define YY_USER_ACTION updating_column();
-
+  #define YY_USER_ACTION updating_column();
 %}
 
 %option noyywrap

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -12,6 +12,26 @@
 
   void yyerror(char* s);
   int yylex();
+  #define YY_USER_ACTION update_loc();
+  static void update_loc(){
+  static int curr_line = 1;
+  static int curr_col  = 1;
+
+  yylloc.first_line   = curr_line;
+  yylloc.first_column = curr_col;
+
+  {char * s; for(s = yytext; *s != '\0'; s++){
+    if(*s == '\n'){
+      curr_line++;
+      curr_col = 1;
+    }else{
+      curr_col++;
+    }
+  }}
+
+  yylloc.last_line   = curr_line;
+  yylloc.last_column = curr_col-1;
+}
 %}
 
 %option noyywrap

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -4,7 +4,8 @@
   #include "symbol_table.h"
 
   int linenumber = 1;
-  int yycolumn = 1;
+  int curr_line = 1;
+  int curr_col  = 1;
   int assignment_flag = 0;
   int for_loop_flag = 0;
   int function_flag = 0;
@@ -14,14 +15,29 @@
   void yyerror(char* s);
   int yylex();
  
-  #define YY_USER_ACTION yylloc.first_line = yylloc.last_line = yylineno; \
-  yylloc.first_column = yycolumn; yylloc.last_column = yycolumn + yyleng - 1; \
-  yycolumn += yyleng; \
+static void updating_column()
+{
+  yylloc.first_line   = curr_line;
+  yylloc.first_column = curr_col;
 
-  #define YYPRINT(File, Type) \
-            yyprint (File, /* FIXME: &yylloc, */ Type, &Value)
-  static void yyprint (FILE *file, /* FIXME: const yyltype *loc, */
-            int type);
+    char * s;
+  for(s = yytext; *s != '\0'; s++)
+    {
+      if(*s == '\n')
+      {
+        curr_line++;
+        curr_col = 0;
+      }
+      else
+      {
+        curr_col++;
+      }
+    }
+  yylloc.last_line   = curr_line;
+  yylloc.last_column = curr_col-1;
+}
+
+#define YY_USER_ACTION updating_column();
 
 %}
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -4,6 +4,7 @@
   #include "symbol_table.h"
 
   int linenumber = 1;
+  int yycolumn = 1;
   int assignment_flag = 0;
   int for_loop_flag = 0;
   int function_flag = 0;
@@ -12,26 +13,16 @@
 
   void yyerror(char* s);
   int yylex();
-  #define YY_USER_ACTION update_loc();
-  static void update_loc(){
-  static int curr_line = 1;
-  static int curr_col  = 1;
+ 
+  #define YY_USER_ACTION yylloc.first_line = yylloc.last_line = yylineno; \
+  yylloc.first_column = yycolumn; yylloc.last_column = yycolumn + yyleng - 1; \
+  yycolumn += yyleng; \
 
-  yylloc.first_line   = curr_line;
-  yylloc.first_column = curr_col;
+  #define YYPRINT(File, Type) \
+            yyprint (File, /* FIXME: &yylloc, */ Type, &Value)
+  static void yyprint (FILE *file, /* FIXME: const yyltype *loc, */
+            int type);
 
-  {char * s; for(s = yytext; *s != '\0'; s++){
-    if(*s == '\n'){
-      curr_line++;
-      curr_col = 1;
-    }else{
-      curr_col++;
-    }
-  }}
-
-  yylloc.last_line   = curr_line;
-  yylloc.last_column = curr_col-1;
-}
 %}
 
 %option noyywrap

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@ extern int yyparse();
 extern FILE* yyin;
 
 extern int linenumber;
-extern int curr_col;
+extern int columnnumber;
 extern ast_node *ast;
 
 const char *argp_program_version = TOSTRING(VERSION_NUMBER);
@@ -232,6 +232,6 @@ int main(int argc, char** argv)
 
 void yyerror (const char *s) 
 {
-    fprintf (stderr, "%d %d : error: %s\n", linenumber, curr_col, s);
+    fprintf (stderr, "Error: Line:%d Column:%d  %s\n", linenumber, columnnumber, s);
     exit(0);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@ extern int yyparse();
 extern FILE* yyin;
 
 extern int linenumber;
-extern int yycolumn;
+extern int curr_col;
 extern ast_node *ast;
 
 const char *argp_program_version = TOSTRING(VERSION_NUMBER);
@@ -232,6 +232,6 @@ int main(int argc, char** argv)
 
 void yyerror (const char *s) 
 {
-    fprintf (stderr, "%d %d : error: %s\n", linenumber, yycolumn, s);
+    fprintf (stderr, "%d %d : error: %s\n", linenumber, curr_col, s);
     exit(0);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -17,6 +17,7 @@ extern int yyparse();
 extern FILE* yyin;
 
 extern int linenumber;
+extern int yycolumn;
 extern ast_node *ast;
 
 const char *argp_program_version = TOSTRING(VERSION_NUMBER);
@@ -231,6 +232,6 @@ int main(int argc, char** argv)
 
 void yyerror (const char *s) 
 {
-    fprintf (stderr, "%d : error: %s\n", linenumber, s);
+    fprintf (stderr, "%d %d : error: %s\n", linenumber, yycolumn, s);
     exit(0);
 }

--- a/src/parser.y
+++ b/src/parser.y
@@ -12,7 +12,6 @@ extern int yyparse();
 extern FILE* yyin;
 
 extern int linenumber;
-extern int yycolumn;
 extern int assignment_flag;
 sym_ptr temp = NULL;
 ast_node *ast = NULL;

--- a/src/parser.y
+++ b/src/parser.y
@@ -19,6 +19,7 @@ ast_node *ast = NULL;
 #define YYDEBUG 1
 %}
 
+%locations
 %define parse.error verbose
 %glr-parser 
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -12,6 +12,7 @@ extern int yyparse();
 extern FILE* yyin;
 
 extern int linenumber;
+extern int yycolumn;
 extern int assignment_flag;
 sym_ptr temp = NULL;
 ast_node *ast = NULL;


### PR DESCRIPTION
This PR adds column number in error message for precise error location.
yylloc and %locations directive are used for getting the column number of error location.